### PR TITLE
Update install_tuya-convert.sh

### DIFF
--- a/install_tuya-convert.sh
+++ b/install_tuya-convert.sh
@@ -27,7 +27,7 @@ apt update
 apt upgrade -y
 apt install -y git curl net-tools samba libssl-dev
 git clone -b new-api https://github.com/kueblc/tuya-convert
-find tuya-convert -name \*.sh -exec sed -i -e "s/sudo -E//" -e "s/sudo //" {} \;
+find tuya-convert -name \*.sh -exec sed -i -e "s/sudo -E//" -e "s/sudo -H//" -e "s/sudo //" {} \;
 cd tuya-convert
 ./install_prereq.sh
 systemctl disable mosquitto


### PR DESCRIPTION
There are now some "sudo -H pip3" commands in tuya-convert/install_prereq.sh
When the sudo commands get stripped out, that leaves "-H pip3" which results in an error during the proxmox container creation.